### PR TITLE
Fix insecure dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   ],
   "dependencies": {
-    "request": "=2.45.0"
+    "request": "=2.67.0"
   },
   "devDependencies": {
     "mocha": "=1.20.1",


### PR DESCRIPTION
The required version of `request` depends on a [hawk version that is vulnerable](https://nodesecurity.io/advisories/77). Sinon and Express could also use a bump, but since they are dev dependencies I'll leave that to you guys.

See [here](https://www.bithound.io/github/pusher/pusher-http-node) for an overview.