### PR TITLE
Generate parse.js on prepublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "5"
+  - "4"
   - "0.12"
-  - "0.11"
-  - "0.10"
-  - "0.8"
 install:
-  - npm install --no-optional
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ node_js:
   - "5"
   - "4"
   - "0.12"
+  - "0.11"
+  - "0.10"
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -29,14 +29,13 @@
     "expect.js": "=0.3.1",
     "sinon": "=1.10.2",
     "nock": "=0.28.0",
-    "express": "=3.11.0"
-  },
-  "optionalDependencies": {
+    "express": "=3.11.0",
     "webpack": "^1.12.9"
   },
   "scripts": {
     "test": "node node_modules/.bin/mocha tests/integration/**/*.js",
-    "parse-build": "echo 'Creating build for Parse Cloud.' && node ./node_modules/.bin/webpack --config=./parse.webpack.js"
+    "parse-build": "echo 'Creating build for Parse Cloud.' && webpack --config=./parse.webpack.js",
+    "prepublish": "npm run parse-build"
   },
   "keywords": ["pusher", "websockets", "realtime"],
   "license": "MIT",


### PR DESCRIPTION
So no one will have to generate it themselves.

We need an empty `.npmignore` so npm uses that instead of the `gitignore` and pushes the generated `parse.js` when we publish.

This also moves Webpack to be a dev dep which might break Travis on Node 0.8 but we should really start to encourage our users to move away from that. I would propose releasing a new version with this change that stops 0.8 support (officially) - and anyone who _really_ needs it can use an older version or hope it works (in theory there's no reason it should stop working on 0.8 anytime soon).