### PR TITLE
update max channel from 10 to 100

### DIFF
--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -119,7 +119,7 @@ Pusher.prototype.authenticate = function(socketId, channel, data) {
  * completes with code < 400, error will be null. Otherwise, error will be
  * populated with response details.
  *
- * @param {String|String[]} channel list of at most 10 channels
+ * @param {String|String[]} channel list of at most 100 channels
  * @param {String} event event name
  * @param data event data, objects are JSON-encoded
  * @param {String} [socketId] id of a socket that should not receive the event
@@ -142,8 +142,8 @@ Pusher.prototype.trigger = function(channels, event, data, socketId, callback) {
   if (event.length > 200) {
     throw new Error("Too long event name: '" + event + "'");
   }
-  if (channels.length > 10) {
-    throw new Error("Can't trigger a message to more than 10 channels");
+  if (channels.length > 100) {
+    throw new Error("Can't trigger a message to more than 100 channels");
   }
   for (var i = 0; i < channels.length; i++) {
     validateChannel(channels[i]);

--- a/tests/integration/pusher/trigger.js
+++ b/tests/integration/pusher/trigger.js
@@ -183,15 +183,19 @@ describe("Pusher", function() {
       });
     });
 
-    it("should throw an error if called with more than 10 channels", function() {
+    it("should throw an error if called with more than 100 channels", function() {
+      var channel = [];
+      for (var i = 1; i <= 101; i++) {
+          channel.push(i);
+      }
       expect(function() {
         pusher.trigger(
-          ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"], "x", {}
+          channel, "x", {}
         );
       }).to.throwError(function(e) {
         expect(e).to.be.an(Error);
         expect(e.message).to.equal(
-          "Can't trigger a message to more than 10 channels"
+          "Can't trigger a message to more than 100 channels"
         );
       });
     });


### PR DESCRIPTION
We can send message to max 100 channels in one request.

reference：https://pusher.com/docs/rest_api#method-post-event