### PR TITLE
Correct the createSignedQueryString example

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,15 +362,15 @@ webhook.getTime();
 If you wanted to send the REST API requests manually (e.g. using a different HTTP client), you can use the `createSignedQueryString` method to generate the whole request query string that includes the auth keys and your parameters.
 
 ```javascript
-pusher.createSignedQueryString(options);
+pusher.createSignedQueryString({
+  method: "POST",                                              // the HTTP request method
+  path: "/apps/3/events",                                      // the HTTP request path
+  body: '{"name":"foo","channel":"donuts","data":"2-for-1"}',  // optional, the HTTP request body
+  params: {},                                                  // optional, the query params
+});
 ```
 
-The only argument needs must be an object with following keys:
-- method - the HTTP request method
-- body - optional, the HTTP request body
-- params - optional, the object representing the query params
-
-Query parameters can't contain following keys, as they are used to sign the request:
+The `params` object can't contain following keys, as they are used to sign the request:
 
 - auth_key
 - auth_timestamp


### PR DESCRIPTION
- Pass required `path` argument
- Make it an example