### PR TITLE
Require package.json with explicit file extension

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-module.exports = require('../package').version;
+module.exports = require('../package.json').version;


### PR DESCRIPTION
Context: Zeit Now v2 has a pure request/response model, with no room for long-running connections. Pusher Channels can fill in here. I would guess Node.js is the most popular language on Zeit Now, so pusher-http-node would be our most used library. But [pusher-http-node is currently unusable on Zeit Now v2](https://spectrum.chat/?t=6d546cd5-61f1-487d-a82a-4e578ab1d642). The underlying bug is on Zeit's end: https://github.com/zeit/ncc/issues/22. But we can fix this sooner ourselves with the change in this PR.