### PR TITLE
RFC: Reduce dependency on Pusher object by move method off prototype

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 var util = require('./util');
 
-function getSocketSignature(pusher, token, channel, socketID, data) {
+function getSocketSignature(encryptionMasterKey, token, channel, socketID, data) {
   var result = {};
 
   var signatureData = [socketID, channel];
@@ -13,10 +13,10 @@ function getSocketSignature(pusher, token, channel, socketID, data) {
   result.auth = token.key + ':' + token.sign(signatureData.join(":"));
 
   if (util.isEncryptedChannel(channel)) {
-    if (pusher.config.encryptionMasterKey === undefined) {
+    if (encryptionMasterKey === undefined) {
       throw new Error("Cannot generate shared_secret because encryptionMasterKey is not set");
     }
-    result.shared_secret = Buffer(pusher.channelSharedSecret(channel)).toString('base64');
+    result.shared_secret = Buffer(util.channelSharedSecret(encryptionMasterKey, channel)).toString('base64');
   }
 
   return result;

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,8 +1,8 @@
 var util = require('./util');
 var nacl = require('tweetnacl');
 
-function encrypt(pusher, channel, data) {
-  if (pusher.config.encryptionMasterKey === undefined) {
+function encrypt(encryptionMasterKey, channel, data) {
+  if (encryptionMasterKey === undefined) {
     throw new Error("Set encryptionMasterKey before triggering events on encrypted channels");
   }
 
@@ -11,7 +11,7 @@ function encrypt(pusher, channel, data) {
   const ciphertextBytes = nacl.secretbox(
     Buffer.from(JSON.stringify(data), 'utf8'),
     nonceBytes,
-    pusher.channelSharedSecret(channel));
+    util.channelSharedSecret(encryptionMasterKey, channel));
 
   return JSON.stringify({
     nonce: Buffer(nonceBytes).toString('base64'),
@@ -53,7 +53,7 @@ exports.trigger = function(pusher, channels, eventName, data, socketId, callback
 exports.triggerBatch = function(pusher, batch, callback) {
   for (var i = 0; i < batch.length; i++) {
     batch[i].data = util.isEncryptedChannel(batch[i].channel) ?
-      encrypt(pusher, batch[i].channel, batch[i].data) :
+      encrypt(pusher.config.encryptionMasterKey, batch[i].channel, batch[i].data) :
       ensureJSON(batch[i].data);
   }
   pusher.post({ path: '/batch_events', body: { batch: batch } }, callback);

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -107,7 +107,7 @@ Pusher.prototype.authenticate = function(socketId, channel, data) {
   validateSocketId(socketId);
   validateChannel(channel);
 
-  return auth.getSocketSignature(this, this.config.token, channel, socketId, data);
+  return auth.getSocketSignature(this.config.encryptionMasterKey, this.config.token, channel, socketId, data);
 };
 
 /** Triggers an event.
@@ -230,10 +230,6 @@ Pusher.prototype.webhook = function(request) {
 Pusher.prototype.createSignedQueryString = function(options) {
   return requests.createSignedQueryString(this.config.token, options);
 };
-
-Pusher.prototype.channelSharedSecret = function(channel) {
-  return crypto.createHash('sha256').update(channel + this.config.encryptionMasterKey).digest();
-}
 
 /** Exported {@link Token} constructor. */
 Pusher.Token = Token;

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,6 +38,10 @@ function secureCompare(a, b) {
   return result === 0;
 }
 
+function channelSharedSecret(encryptionMasterKey, channel) {
+  return crypto.createHash('sha256').update(channel + encryptionMasterKey).digest();
+}
+
 function isEncryptedChannel(channel) {
   return channel.startsWith("private-encrypted-");
 }
@@ -46,4 +50,5 @@ exports.toOrderedArray = toOrderedArray;
 exports.mergeObjects = mergeObjects;
 exports.getMD5 = getMD5;
 exports.secureCompare = secureCompare;
+exports.channelSharedSecret = channelSharedSecret;
 exports.isEncryptedChannel = isEncryptedChannel;


### PR DESCRIPTION
I didn't like how the Pusher object was being passed down so deep in the call stack, when the functions that were being used didn't really depend on anything in the Pusher object. This PR makes channelSharedSecret and isEncryptedChannel plain functions in util.js. This means the Pusher object does not need to be passed to encrypt() and getSocketSignature().

It's a pretty minor change and I don't feel too strongly, so feel free to discount.