### PR TITLE
Deprecated `encrypted` parameter in favour of `useTLS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ var pusher = new Pusher({
   appId: 'APP_ID',
   key: 'APP_KEY',
   secret: 'SECRET_KEY',
-  encrypted: ENCRYPTED, // optional, defaults to false
+  useTLS: USE_TLS, // optional, defaults to false
   cluster: 'CLUSTER', // if `host` is present, it will override the `cluster` option.
   host: 'HOST', // optional, defaults to api.pusherapp.com
-  port: PORT, // optional, defaults to 80 for unencrypted and 443 for encrypted
+  port: PORT, // optional, defaults to 80 for non-TLS connections and 443 for TLS connections
 });
 ```
 
@@ -68,8 +68,8 @@ var pusher = Pusher.forCluster("CLUSTER", {
   appId: 'APP_ID',
   key: 'APP_KEY',
   secret: 'SECRET_KEY',
-  encrypted: ENCRYPTED, // optional, defaults to false
-  port: PORT, // optional, defaults to 80 for unencrypted and 443 for encrypted
+  useTLS: USE_TLS, // optional, defaults to false
+  port: PORT, // optional, defaults to 80 for non-TLS connections and 443 for TLS connections
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ declare namespace Pusher {
     appId: string;
     key: string;
     secret: string;
+    useTLS?: boolean;
     encrypted?: boolean;
     proxy?: string;
     timeout?: number;

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,9 @@ function Config(options) {
   options = options || {};
 
   var useTLS = false;
-  if (options.useTLS !== undefined) {
+  if (options.useTLS !== undefined && options.encrypted !== undefined) {
+    throw new Error("Cannot set both `useTLS` and `encrypted` configuration options");
+  } else if (options.useTLS !== undefined) {
     useTLS = options.useTLS;
   } else if (options.encrypted !== undefined) {
     // `encrypted` deprecated in favor of `useTLS`

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,15 @@ var Token = require('./token');
 function Config(options) {
   options = options || {};
 
-  this.scheme = options.scheme || (options.encrypted ? "https" : "http");
+  var useTLS = false;
+  if (options.useTLS !== undefined) {
+    useTLS = options.useTLS;
+  } else if (options.encrypted !== undefined) {
+    // `encrypted` deprecated in favor of `useTLS`
+    console.warn("`encrypted` option is deprecated in favor of `useTLS`");
+    useTLS = options.encrypted;
+  }
+  this.scheme = options.scheme || (useTLS ? "https" : "http");
   this.port = options.port;
 
   this.appId = options.appId;

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -40,8 +40,9 @@ var validateSocketId = function(socketId) {
  * @param {Object} options
  * @param {String} [options.host="api.pusherapp.com"] API hostname
  * @param {String} [options.notification_host="api.pusherapp.com"] Notification API hostname
- * @param {Boolean} [options.encrypted=false] whether to use SSL
- * @param {Boolean} [options.notification_encrypted=false] whether to use SSL for notifications
+ * @param {Boolean} [options.useTLS=false] whether to use TLS
+ * @param {Boolean} [options.encrypted=false] deprecated; renamed to `useTLS`
+ * @param {Boolean} [options.notification_encrypted=false] whether to use TLS for notifications
  * @param {Integer} [options.port] port, default depends on the scheme
  * @param {Integer} options.appId application ID
  * @param {String} options.key application key

--- a/tests/integration/pusher/constructor.js
+++ b/tests/integration/pusher/constructor.js
@@ -18,13 +18,23 @@ describe("Pusher", function() {
       expect(pusher.config.token.secret).to.equal("fedcba0987654321");
     });
 
-    it("should default `encrypted` to false", function() {
+    it("should default `useTLS` to false", function() {
       var pusher = new Pusher({});
       expect(pusher.config.scheme).to.equal("http");
     });
 
-    it("should support `encrypted`", function() {
+    it("should support `useTLS`", function() {
+      var pusher = new Pusher({ useTLS: true });
+      expect(pusher.config.scheme).to.equal("https");
+    });
+
+    it("should support deprecated `encrypted`", function() {
       var pusher = new Pusher({ encrypted: true });
+      expect(pusher.config.scheme).to.equal("https");
+    });
+
+    it("should use `useTLS` in favor of deprecated `encrypted`", function() {
+      var pusher = new Pusher({ useTLS: true, encrypted: false });
       expect(pusher.config.scheme).to.equal("https");
     });
 
@@ -49,7 +59,7 @@ describe("Pusher", function() {
     });
 
     it("should default `port` to undefined", function() {
-      var pusher = new Pusher({ encrypted: true });
+      var pusher = new Pusher({ useTLS: true });
       expect(pusher.config.port).to.be(undefined);
     });
 
@@ -57,7 +67,7 @@ describe("Pusher", function() {
       var pusher = new Pusher({ port: 8080 });
       expect(pusher.config.port).to.equal(8080);
 
-      pusher = new Pusher({ encrypted: true, port: 8080 });
+      pusher = new Pusher({ useTLS: true, port: 8080 });
       expect(pusher.config.port).to.equal(8080);
     });
 

--- a/tests/integration/pusher/constructor.js
+++ b/tests/integration/pusher/constructor.js
@@ -33,9 +33,10 @@ describe("Pusher", function() {
       expect(pusher.config.scheme).to.equal("https");
     });
 
-    it("should use `useTLS` in favor of deprecated `encrypted`", function() {
-      var pusher = new Pusher({ useTLS: true, encrypted: false });
-      expect(pusher.config.scheme).to.equal("https");
+    it("should throw an exception if `useTLS` and `encrypted` are set", function() {
+      expect(function() {
+        new Pusher({ useTLS: true, encrypted: false });
+      }).to.throwException(/^Cannot set both `useTLS` and `encrypted` configuration options$/);
     });
 
     it("should default `host` to 'api.pusherapp.com'", function() {

--- a/tests/integration/pusher/get.js
+++ b/tests/integration/pusher/get.js
@@ -87,7 +87,7 @@ describe("Pusher", function() {
         appId: 999,
         key: "111111",
         secret: "beef",
-        encrypted: true,
+        useTLS: true,
         host: "example.com",
         port: 1234
       });

--- a/tests/integration/pusher/post.js
+++ b/tests/integration/pusher/post.js
@@ -109,7 +109,7 @@ describe("Pusher", function() {
         appId: 10000,
         key: "aaaa",
         secret: "beef",
-        encrypted: true,
+        useTLS: true,
         host: "example.com",
         port: 1234
       });

--- a/tests/integration/pusher/trigger.js
+++ b/tests/integration/pusher/trigger.js
@@ -241,7 +241,7 @@ describe("Pusher", function() {
         appId: 1234,
         key: "f00d",
         secret: "beef",
-        encrypted: true,
+        useTLS: true,
         host: "example.com",
         port: 1234
       });


### PR DESCRIPTION
It is more accurate and will avoid confusion with end-to-end encryption.