### PR TITLE
Add user_info to PresenceChannelData

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ declare namespace Pusher {
 
   export interface PresenceChannelData {
     user_id: string;
+    user_info: { [key: string]: string };
   }
 
   export interface WebHookRequest {


### PR DESCRIPTION
According to docs, you can provide a second argument to the `authenticate` method when authenticating for a presence channel.