### PR TITLE
Add support for using Fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ To import `Pusher`:
 var Pusher = require('cloud/modules/node_modules/pusher/parse');
 ```
 
+### Fetch
+
+Particularly useful for use in a [Cloudflare Worker](https://workers.cloudflare.com/), you can use the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) instead of `request`:
+
+Then to build the file bundle for Fetch:
+
+    $ cd node_modules/pusher
+    $ npm i
+
+To import `Pusher`:
+
+```js
+var Pusher = require('pusher/fetch');
+```
+
 ## Importing
 
 It's possible to use pusher-http-node with typescript or javascript.

--- a/fetch.webpack.js
+++ b/fetch.webpack.js
@@ -1,0 +1,24 @@
+/*
+Bundler used to create the Fetch module.
+ */
+
+var path = require("path");
+
+module.exports = {
+  entry: "./lib/pusher",
+  output: {
+    library: "Pusher",
+    path: __dirname,
+    libraryTarget: "commonjs2",
+    filename: "fetch.js",
+  },
+  target: "node",
+  resolve: {
+    alias: {
+      request: "./fetch/request",
+    },
+  },
+  externals: {
+    "./version": "var { 'version' : '" + require("./package").version + "'}",
+  },
+};

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -1,0 +1,45 @@
+module.exports = ParseRequest = {
+  get: function (params, callback) {
+    this._request("GET", params, callback);
+  },
+
+  post: function (params, callback) {
+    this._request("POST", params, callback);
+  },
+
+  _request: function (method, params, callback) {
+    var request = {
+      method: method,
+      headers: params.headers,
+      body: params.body,
+    };
+
+    var success = function (res) {
+      var err = null;
+      var res = new ParseResponse(res);
+      var body = res.body;
+      callback(err, res, body);
+    };
+
+    var error = function (res) {
+      var res = new ParseResponse(res);
+      var err = (body = res.body);
+      callback(err, res, body);
+    };
+
+    fetch(params.url, request).then(success).catch(error);
+  },
+
+  forever: function () {
+    return this;
+  },
+};
+
+function ParseResponse(raw) {
+  this.statusCode = raw.status;
+  this.body = raw.body;
+
+  // For convenience, expose some Response helper methods.
+  this.text = () => raw.text();
+  this.json = () => raw.json();
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "local-test": "node_modules/.bin/mocha tests/integration/**/*.js",
     "test": "node_modules/.bin/mocha tests/{integration,remote}/**/*.js",
     "parse-build": "echo 'Creating build for Parse Cloud.' && webpack --config=./parse.webpack.js",
-    "prepublish": "npm run parse-build"
+    "fetch-build": "echo 'Creating build for Fetch.' && webpack --config=./fetch.webpack.js",
+    "prepublish": "npm run parse-build && npm run fetch-build"
   },
   "keywords": [
     "pusher",


### PR DESCRIPTION
Similar to with Parse Cloud, add a build which uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), (particularly useful for use in [Cloudflare Workers](https://workers.cloudflare.com/)).