### PR TITLE
Consistent encoding for shared secret

### DIFF
--- a/examples/typescript/main.ts
+++ b/examples/typescript/main.ts
@@ -4,8 +4,7 @@ import * as Pusher from "pusher"
 
 const pusher = Pusher.forURL(process.env.PUSHER_URL, {
   encryptionMasterKeyBase64: Buffer.from(
-    "01234567890123456789012345678901",
-    "binary"
+    "01234567890123456789012345678901"
   ).toString("base64"),
   agent: new Agent({ keepAlive: true }),
 })

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,7 +49,7 @@ function Config(options) {
       )
     }
 
-    this.encryptionMasterKey = options.encryptionMasterKey
+    this.encryptionMasterKey = Buffer.from(options.encryptionMasterKey)
   }
 
   // Handle base64 encoded 32 byte key to encourage use of the full range of byte values
@@ -61,10 +61,7 @@ function Config(options) {
       throw new Error("encryptionMasterKeyBase64 must be valid base64")
     }
 
-    const decodedKey = Buffer.from(
-      options.encryptionMasterKeyBase64,
-      "base64"
-    ).toString("binary")
+    const decodedKey = Buffer.from(options.encryptionMasterKeyBase64, "base64")
     if (decodedKey.length !== 32) {
       throw new Error(
         "encryptionMasterKeyBase64 must decode to 32 bytes, but the string " +

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -230,7 +230,9 @@ Pusher.prototype.createSignedQueryString = function (options) {
 Pusher.prototype.channelSharedSecret = function (channel) {
   return crypto
     .createHash("sha256")
-    .update(channel + this.config.encryptionMasterKey)
+    .update(
+      Buffer.concat([Buffer.from(channel), this.config.encryptionMasterKey])
+    )
     .digest()
 }
 

--- a/tests/integration/pusher/authenticate.js
+++ b/tests/integration/pusher/authenticate.js
@@ -149,14 +149,14 @@ describe("Pusher", function () {
 describe("Pusher with encryptionMasterKey", function () {
   let pusher
 
-  const testMasterKey = "01234567890123456789012345678901"
+  const testMasterKeyBase64 = "zyrm8pvV2C9fJcBfhyXzvxbJVN/H7QLmbe0xJi1GhPU="
 
   beforeEach(function () {
     pusher = new Pusher({
       appId: 1234,
       key: "f00d",
       secret: "tofu",
-      encryptionMasterKey: testMasterKey,
+      encryptionMasterKeyBase64: testMasterKeyBase64,
     })
   })
 
@@ -168,7 +168,7 @@ describe("Pusher with encryptionMasterKey", function () {
         auth:
           "f00d:962c48b78bf93d98ff4c92ee7dff04865821455b7b401e9d60a9e0a90af2c105",
         channel_data: '"foo"',
-        shared_secret: "BYBsePpRCQkGPvbWu/5j8x+MmUF5sgPH5DmNBwkTzYs=",
+        shared_secret: "nlr49ISQHz91yS3cy/yWmW8wFMNeTnNL5tNHnbPJcLQ=",
       })
     })
     it("should not return a shared_secret for non-encrypted channels", function () {

--- a/tests/integration/pusher/constructor.js
+++ b/tests/integration/pusher/constructor.js
@@ -102,7 +102,7 @@ describe("Pusher", function () {
     it("should support `encryptionMasterKey` of 32 bytes", function () {
       const key = "01234567890123456789012345678901"
       const pusher = new Pusher({ encryptionMasterKey: key })
-      expect(pusher.config.encryptionMasterKey).to.equal(key)
+      expect(pusher.config.encryptionMasterKey.toString()).to.equal(key)
     })
 
     it("should reject `encryptionMasterKey` of 31 bytes", function () {
@@ -121,14 +121,14 @@ describe("Pusher", function () {
 
     it("should support `encryptionMasterKeyBase64` which decodes to 32 bytes", function () {
       const key = "01234567890123456789012345678901"
-      const keyBase64 = Buffer.from(key, "binary").toString("base64")
+      const keyBase64 = Buffer.from(key).toString("base64")
       const pusher = new Pusher({ encryptionMasterKeyBase64: keyBase64 })
-      expect(pusher.config.encryptionMasterKey).to.equal(key)
+      expect(pusher.config.encryptionMasterKey.toString()).to.equal(key)
     })
 
     it("should reject `encryptionMasterKeyBase64` which decodes to 31 bytes", function () {
       const key = "0123456789012345678901234567890"
-      const keyBase64 = Buffer.from(key, "binary").toString("base64")
+      const keyBase64 = Buffer.from(key).toString("base64")
       expect(function () {
         new Pusher({ encryptionMasterKeyBase64: keyBase64 })
       }).to.throwException(/31 bytes/)
@@ -136,7 +136,7 @@ describe("Pusher", function () {
 
     it("should reject `encryptionMasterKeyBase64` which decodes to 33 bytes", function () {
       const key = "012345678901234567890123456789012"
-      const keyBase64 = Buffer.from(key, "binary").toString("base64")
+      const keyBase64 = Buffer.from(key).toString("base64")
       expect(function () {
         new Pusher({ encryptionMasterKeyBase64: keyBase64 })
       }).to.throwException(/33 bytes/)

--- a/tests/integration/pusher/trigger.js
+++ b/tests/integration/pusher/trigger.js
@@ -421,8 +421,7 @@ describe("Pusher with encryptionMasterKey", function () {
   let pusher
 
   const testMasterKey = Buffer.from(
-    "01234567890123456789012345678901",
-    "binary"
+    "01234567890123456789012345678901"
   ).toString("base64")
 
   beforeEach(function () {


### PR DESCRIPTION
This SDK disagrees with the shared secret that the other SDKs produce, because it encodes the master key to a `latin1` string internally, and then concatenated with a `utf8` string (the channel name) before being passed to the `sha256` method which (probably) interprets strings as `utf8`. This is pretty insane, but it still "works" as long as you don't try to use two server libraries simultaneously, because then they will disagree about what the key should be.

Regardless, we should avoid all this encoding nonsense internally by just keeping everything in buffers once we've decoded from base64. After this change pusher-http-node agrees with the ruby and go SDKs at least. I'm going to check the others next.

edit: `binary` is a horribly confusing alias for `latin1`. yuck.