### PR TITLE
fetch is not a function.

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,5 +1,5 @@
-const fetch = require("node-fetch")
-const AbortController = require("abort-controller")
+const fetch = require("node-fetch").default
+const AbortController = require("abort-controller").default
 
 const errors = require("./errors")
 const util = require("./util")


### PR DESCRIPTION
# What
Adding .default to the import of node-fetch

# Why
When this package is deployed as part of a Lambda function it is unable to find fetch, this is because it is loosely imported

# Issue
https://github.com/pusher/pusher-http-node/issues/130