### PR TITLE
Support fetching channel info on trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ pusher.triggerBatch([
 ])
 ```
 
-### Fetch subscriber and user counts at the time of batch publish
+### Fetch subscriber and user counts at the time of publish
 
 For the channels that were published to, you can request for the number of subscribers or user to be returned in the response body.
 
+#### Regular triggering
+
 ```javascript
 pusher
-  .trigger(channel, event, data, { info: "user_count,subscription_count" })
+  .trigger("presence-my-channel", "event", "test", { info: "user_count,subscription_count" })
   .then(response => {
     if (response.status !== 200) {
       throw Error("unexpected status")
@@ -191,11 +193,47 @@ pusher
   .catch(error => {
     // Handle error
   })
+```
 
+#### Batch triggering
+
+```javascript
+const batch = [
+  {
+    channel: "my-channel",
+    name: "event",
+    data: "test1",
+    info: "subscription_count",
+  },
+  {
+    channel: "presence-my-channel",
+    name: "event",
+    data: "test2",
+    info: "user_count,subscription_count",
+  },
+]
 pusher
-  .triggerBatch([{ channel: channel, name: name, data: data, info: "user_count,subscription_count" }])
-  .then(response => {
-    // As above
+  .triggerBatch(batch)
+  .then((response) => {
+    if (response.status !== 200) {
+      throw Error("unexpected status")
+    }
+    // Parse the response body as JSON
+    return response.json()
+  })
+  .then((body) => {
+    body.batch.forEach((attributes, i) => {
+      process.stdout.write(
+        `channel: ${batch[i].channel}, name: ${batch[i].name}, subscription_count: ${attributes.subscription_count}`
+      )
+      if ("user_count" in attributes) {
+        process.stdout.write(`, user_count: ${attributes.user_count}`)
+      }
+      process.stdout.write("\n")
+    })
+  })
+  .catch((error) => {
+    console.error(error)
   })
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,43 @@ You can trigger a batch of up to 10 events.
 
 ### Excluding event recipients
 
-In order to avoid the client that triggered the event from also receiving it, the `trigger` function takes an optional `socketId` parameter. For more informaiton see: <http://pusher.com/docs/publisher_api_guide/publisher_excluding_recipients>.
+In order to avoid the client that triggered the event from also receiving it, a `socket_id` parameter can be added to the `params` object. For more information see: <http://pusher.com/docs/publisher_api_guide/publisher_excluding_recipients>.
 
 ```javascript
-const socketId = "1302.1081607"
-pusher.trigger(channel, event, data, socketId)
+pusher.trigger(channel, event, data, { socket_id: "1302.1081607" })
+
+pusher.triggerBatch([
+  { channel: channel, name: name, data: data, socket_id: "1302.1081607" },
+])
+```
+
+### Fetch subscriber and user counts at the time of batch publish
+
+For the channels that were published to, you can request for the number of subscribers or user to be returned in the response body.
+
+```javascript
+pusher
+  .trigger(channel, event, data, { info: "user_count,subscription_count" })
+  .then(response => {
+    if (response.status !== 200) {
+      throw Error("unexpected status")
+    }
+    // Parse the response body as JSON
+    return response.json()
+  )
+  .then(body => {
+    const channelsInfo = body.channels
+    // Do something with channelsInfo
+  })
+  .catch(error => {
+    // Handle error
+  })
+
+pusher
+  .triggerBatch([{ channel: channel, name: name, data: data, info: "user_count,subscription_count" }])
+  .then(response => {
+    // As above
+  })
 ```
 
 ### End-to-end encryption [BETA]

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ pusher.triggerBatch([
 ])
 ```
 
-### Fetch subscriber and user counts at the time of publish
+### Fetch subscriber and user counts at the time of publish [[EXPERIMENTAL](https://pusher.com/docs/lab#experimental-program)]
 
 For the channels that were published to, you can request for the number of subscribers or user to be returned in the response body.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare class Pusher {
     channel: string | Array<string>,
     event: string,
     data: any,
-    socketId?: string
+    params?: Pusher.TriggerParams
   ): Promise<Response>
 
   trigger(
@@ -61,10 +61,17 @@ declare namespace Pusher {
 
   export type Options = ClusterOptions | HostOptions
 
+  export interface TriggerParams {
+    socket_id?: string
+    info?: string
+  }
+
   export interface BatchEvent {
     channel: string
     name: string
     data: any
+    socket_id?: string
+    info?: string
   }
 
   type ReservedParams =

--- a/lib/events.js
+++ b/lib/events.js
@@ -23,16 +23,14 @@ function encrypt(pusher, channel, data) {
   })
 }
 
-exports.trigger = function (pusher, channels, eventName, data, socketId) {
+exports.trigger = function (pusher, channels, eventName, data, params) {
   if (channels.length === 1 && util.isEncryptedChannel(channels[0])) {
     const channel = channels[0]
     const event = {
       name: eventName,
       data: encrypt(pusher, channel, data),
       channels: [channel],
-    }
-    if (socketId) {
-      event.socket_id = socketId
+      ...params,
     }
     return pusher.post({ path: "/events", body: event })
   } else {
@@ -49,10 +47,9 @@ exports.trigger = function (pusher, channels, eventName, data, socketId) {
       name: eventName,
       data: ensureJSON(data),
       channels: channels,
+      ...params,
     }
-    if (socketId) {
-      event.socket_id = socketId
-    }
+    console.log(event)
     return pusher.post({ path: "/events", body: event })
   }
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -49,7 +49,6 @@ exports.trigger = function (pusher, channels, eventName, data, params) {
       channels: channels,
       ...params,
     }
-    console.log(event)
     return pusher.post({ path: "/events", body: event })
   }
 }

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -130,12 +130,14 @@ Pusher.prototype.authenticate = function (socketId, channel, data) {
  * @param {String|String[]} channel list of at most 100 channels
  * @param {String} event event name
  * @param data event data, objects are JSON-encoded
- * @param {String} [socketId] id of a socket that should not receive the event
+ * @param {Object} [params] additional optional request body parameters
+ * @param {String} [params.socket_id] id of a socket that should not receive the event
+ * @param {String} [params.info] a comma separate list of attributes to be returned in the response
  * @see RequestError
  */
-Pusher.prototype.trigger = function (channels, event, data, socketId) {
-  if (socketId) {
-    validateSocketId(socketId)
+Pusher.prototype.trigger = function (channels, event, data, params) {
+  if (params && params.socket_id) {
+    validateSocketId(params.socket_id)
   }
   if (!(channels instanceof Array)) {
     // add single channel to array for multi trigger compatibility
@@ -150,7 +152,7 @@ Pusher.prototype.trigger = function (channels, event, data, socketId) {
   for (let i = 0; i < channels.length; i++) {
     validateChannel(channels[i])
   }
-  return events.trigger(this, channels, event, data, socketId)
+  return events.trigger(this, channels, event, data, params)
 }
 
 /* Triggers a batch of events
@@ -159,7 +161,9 @@ Pusher.prototype.trigger = function (channels, event, data, socketId) {
  * {
  *   name: string,
  *   channel: string,
- *   data: any JSON-encodable data
+ *   data: any JSON-encodable data,
+ *   socket_id: [optional] string,
+ *   info: [optional] string
  * }
  */
 Pusher.prototype.triggerBatch = function (batch) {

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -132,7 +132,7 @@ Pusher.prototype.authenticate = function (socketId, channel, data) {
  * @param data event data, objects are JSON-encoded
  * @param {Object} [params] additional optional request body parameters
  * @param {String} [params.socket_id] id of a socket that should not receive the event
- * @param {String} [params.info] a comma separate list of attributes to be returned in the response
+ * @param {String} [params.info] a comma separate list of attributes to be returned in the response. Experimental, see https://pusher.com/docs/lab#experimental-program
  * @see RequestError
  */
 Pusher.prototype.trigger = function (channels, event, data, params) {
@@ -163,7 +163,7 @@ Pusher.prototype.trigger = function (channels, event, data, params) {
  *   channel: string,
  *   data: any JSON-encodable data,
  *   socket_id: [optional] string,
- *   info: [optional] string
+ *   info: [optional] string experimental, see https://pusher.com/docs/lab#experimental-program
  * }
  */
 Pusher.prototype.triggerBatch = function (batch) {


### PR DESCRIPTION
Adds support for a new experimental feature of the Channels API:
Specifically the ability to specify an `info` parameter in a
trigger body, or with an event in a batch trigger body. The server
will respond with attributes in the same format as the `/channels`
endpoint.

The `info` param is specified in a "params" object, which is
passed in as the fourth parameter to the `trigger` method. The
`socket_id` parameter is specified in the same way.

Note: this introduces a breaking change for users that were
passing in a `socket_id`.

It is not a breaking change for `triggerBatch`.

`triggerBatch` has also been updated to support `socket_id` being
included as part of event objects.

Resolves https://github.com/pusher/pusher-http-node/issues/134.