### PR TITLE
Add missing user_id property to Event interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,7 @@ declare namespace Pusher {
     event: string
     data: string
     socket_id: string
+    user_id?: string
   }
 
   interface WebHookData {

--- a/index.d.ts
+++ b/index.d.ts
@@ -124,7 +124,7 @@ declare namespace Pusher {
     rawBody: string
   }
 
-  interface Event {
+  export interface Event {
     name: string
     channel: string
     event: string


### PR DESCRIPTION
I believe this corrects an error in the type definition. Based on [the documentation](https://pusher.com/docs/channels/server_api/webhooks#member-added) (and the fact that my code works 🙂) there is a `user_id` property on some webhooks, namely `member_added`.

Question for the maintainers - should I also add this to the `BatchEvent` interface? I wasn't sure what that's used for, since `WebHook.getEvents()` returns `Array<Event>`.

As for the test failures... I don't think they're related to my changeset, but happy to take a look if you think so!

Edit: I also added an `export` to the webhook `Event` type so I can use it in my webhook handlers - hopefully that's an OK change!