### PR TITLE
remove start-of-word character to ensure channels can start with a nu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.2
 
 - [CHANGED] Add types/node-fetch to dependencies.
+
 ## 5.1.1-beta (2022-06-01)
 
 [FIXED] Updated typescript types with new user features.

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -15,7 +15,7 @@ const validateChannel = function (channel) {
   if (
     typeof channel !== "string" ||
     channel === "" ||
-    channel.match(/[^A-Za-z0-9_\-=@,.;]/)
+    channel.match(/[A-Za-z0-9_\-=@,.;]/)
   ) {
     throw new Error("Invalid channel name: '" + channel + "'")
   }


### PR DESCRIPTION
…mber

## What does this PR do?

Fixes https://github.com/pusher/pusher-js/issues/684. 
The current channel validation mandates the channel must start with a letter character. This is not required and can be removed. 

## Checklist

- [ ] All new functionality has tests.
- [ ] All tests are passing.
- [ ] New or changed API methods have been documented.
- [ ] `npm run format` has been run

## CHANGELOG

- [FIXED] fixed the channel validation to allow number only channels 
