### PR TITLE
Add user_id to event interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,6 +167,7 @@ declare namespace Pusher {
     event: string
     data: string
     socket_id: string
+    user_id?: string
   }
 
   interface WebHookData {


### PR DESCRIPTION
## What does this PR do?

Add user_id to event interface, this field comes through in the webhook request if using presence channels.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [x] New or changed API methods have been documented.
- [x] `npm run format` has been run

## CHANGELOG

- [FIXED] Include user_id in the event interface