### PR TITLE
Fix CI: update Node.js test matrix to 18/20/22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Prepare tag
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare tag
         run: |
           export TAG=v$(jq -r '.version' package.json)
@@ -67,8 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-github-release
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           csplit -s CHANGELOG.md "/##/" {1}
           cat xx01 > CHANGELOG.tmp
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG }}
           name: ${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           csplit -s CHANGELOG.md "/##/" {1}
           cat xx01 > CHANGELOG.tmp
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ env.TAG }}
           name: ${{ env.TAG }}

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -11,7 +11,7 @@ jobs:
     name: Prepare release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PUSHER_CI_GITHUB_PRIVATE_TOKEN }}
           fetch-depth: 0
@@ -20,7 +20,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(jq -r '.version' package.json)
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: pusher/actions
           token: ${{ secrets.PUSHER_CI_GITHUB_PRIVATE_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
         with:
           current_version: ${{ env.CURRENT_VERSION }}
           token: ${{ secrets.PUSHER_CI_GITHUB_PRIVATE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - run: npm install

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale PRs
 
 on:
   schedule:
-    - cron: '0 12 * * 1-5'
+    - cron: "0 12 * * 1-5"
 
 jobs:
   stale:
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This PR is stale because it has been open 21 days with no activity. If you would like this issue to stay open please leave a comment indicating how this issue is affecting you. Thank you.'
+          stale-issue-message: "This PR is stale because it has been open 21 days with no activity. If you would like this issue to stay open please leave a comment indicating how this issue is affecting you. Thank you."
           days-before-pr-stale: 14
           days-before-issue-stale: -1
           days-before-pr-close: 21
           days-before-issue-close: -1
-          exempt-issue-labels: 'pinned,security,bug'
+          exempt-issue-labels: "pinned,security,bug"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: "This PR is stale because it has been open 21 days with no activity. If you would like this issue to stay open please leave a comment indicating how this issue is affecting you. Thank you."
           days-before-pr-stale: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10.x, 10.x, 12.x, 14.x]
+        node: [18.x, 20.x, 22.x]
 
     name: Node.js ${{ matrix.node }} Test
 
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
## Summary

* [Fixed] Replace EOL Node.js versions (10.x, 12.x, 14.x) with current LTS versions (18.x, 20.x, 22.x)
* [Fixed] Remove duplicate 10.x entry in test matrix
* [Fixed] Resolves gyp build failure caused by Python 3.12+ incompatibility with old node-gyp
* [Updated] Bump actions/checkout from v4 to v6
* [Updated] Bump actions/setup-node from v2 to v6
* [Updated] Bump actions/stale from v9 to v10
* [Updated] Bump softprops/action-gh-release from v2 to v3
* [Fixed] Pin softprops/action-gh-release to commit SHA to resolve CodeQL unpinned action warning
* [Fixed] Fix Prettier formatting in stale.yml