### PR TITLE
Redact encryption master key from config validation error messages

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,10 +40,10 @@ function Config(options) {
       throw new Error("encryptionMasterKey must be a string")
     }
     if (options.encryptionMasterKey.length !== 32) {
+      // Security: never include the key value in the error message — the key is a
+      // secret and error messages can propagate to logs, error trackers, or HTTP responses.
       throw new Error(
-        "encryptionMasterKey must be 32 bytes long, but the string '" +
-          options.encryptionMasterKey +
-          "' is " +
+        "encryptionMasterKey must be 32 bytes long, but the provided key is " +
           options.encryptionMasterKey.length +
           " bytes long"
       )
@@ -63,10 +63,10 @@ function Config(options) {
 
     const decodedKey = Buffer.from(options.encryptionMasterKeyBase64, "base64")
     if (decodedKey.length !== 32) {
+      // Security: never include the key value in the error message — the key is a
+      // secret and error messages can propagate to logs, error trackers, or HTTP responses.
       throw new Error(
-        "encryptionMasterKeyBase64 must decode to 32 bytes, but the string " +
-          options.encryptionMasterKeyBase64 +
-          "' decodes to " +
+        "encryptionMasterKeyBase64 must decode to 32 bytes, but the provided key decodes to " +
           decodedKey.length +
           " bytes"
       )


### PR DESCRIPTION
### Summary
The two key-length validation checks in `lib/config.js` interpolate the **full `encryptionMasterKey` / `encryptionMasterKeyBase64` value** into the thrown `Error`. Since that key is the root secret for E2E encrypted channels and exceptions routinely propagate to logs, error-tracking services, CI output, and HTTP error responses, a length mismatch (e.g. a stray trailing newline, or passing a base64 key to the raw-bytes option) can persist the live key in those sinks.

This reports only the **key length** in the error, never the value. No other functional change.

### Tests
Existing assertions match the byte-count text (`… bytes long` / `decodes to N bytes`), which is preserved — no test changes needed.