### PR TITLE
Release 5.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 5.3.4
-
-- [SECURITY] Redact the encryption master key value from config validation error messages
-- [FIXED] Update CI Node.js test matrix to 18/20/22 and fix gyp build failure
-- [CHANGED] Pin GitHub Actions to commit SHAs and bump actions/checkout, actions/setup-node, actions/stale, and softprops/action-gh-release
-
 ## 5.3.3
 
 - [FIXED] Bump node-fetch to ^2.7.0, express to ^4.22.1, eslint to ^7.32.0, mocha to ^9.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.3.4
+
+- [SECURITY] Redact the encryption master key value from config validation error messages
+- [FIXED] Update CI Node.js test matrix to 18/20/22 and fix gyp build failure
+- [CHANGED] Pin GitHub Actions to commit SHAs and bump actions/checkout, actions/setup-node, actions/stale, and softprops/action-gh-release
+
 ## 5.3.3
 
 - [FIXED] Bump node-fetch to ^2.7.0, express to ^4.22.1, eslint to ^7.32.0, mocha to ^9.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.3.4
+
+- [SECURITY] Redact the encryption master key value from config validation error messages (#239)
+- [FIXED] Update CI Node.js test matrix to 18/20/22 and fix gyp build failure (#237)
+- [CHANGED] Pin GitHub Actions to commit SHAs and bump actions/checkout, actions/setup-node, actions/stale, and softprops/action-gh-release
+
 ## 5.3.3
 
 - [FIXED] Bump node-fetch to ^2.7.0, express to ^4.22.1, eslint to ^7.32.0, mocha to ^9.2.2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pusher",
   "description": "Node.js client to interact with the Pusher Channels REST API",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "author": "Pusher <support@pusher.com>",
   "contributors": [
     {


### PR DESCRIPTION
Release 5.3.4.

Changes since 5.3.3 (currently published on npm). The release action regenerates CHANGELOG.md from the bullet list below.

## CHANGELOG

- [SECURITY] Redact the encryption master key value from config validation error messages (#239)
- [FIXED] Update CI Node.js test matrix to 18/20/22 and fix gyp build failure (#237)
- [CHANGED] Pin GitHub Actions to commit SHAs and bump actions/checkout, actions/setup-node, actions/stale, and softprops/action-gh-release